### PR TITLE
native support for flags and arguments

### DIFF
--- a/app.go
+++ b/app.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -22,6 +23,7 @@ type Config struct {
 	ExecName string
 	Version  string
 	Desc     string
+	Options  *flag.FlagSet
 }
 
 // App is a Temporal command line app
@@ -36,7 +38,7 @@ func New(cmds map[string]Cmd, cfg Config) *App {
 	app.cmds["help"] = Cmd{
 		Blurb:       "show help text",
 		Description: fmt.Sprintf("Display help text for %s or the given command", cfg.Name),
-		Action:      func(config.TemporalConfig, map[string]string) { app.help() },
+		Action:      func(config.TemporalConfig, map[string]string) { app.help(os.Args[1:]) },
 		PreRun:      true,
 	}
 	if cfg.Version != "" {
@@ -55,9 +57,18 @@ func New(cmds map[string]Cmd, cfg Config) *App {
 // for example the built-in "help" command.
 func (a *App) PreRun(args []string) int {
 	if len(args) == 0 {
-		a.help()
+		a.help(args)
 		return CodeOK
 	}
+
+	if a.cfg.Options != nil {
+		if err := a.cfg.Options.Parse(args); err != nil {
+			a.noop(args)
+			return CodeNoOp
+		}
+		args = a.cfg.Options.Args()
+	}
+
 	prerunCmds := make(map[string]Cmd)
 	for exec, cmd := range a.cmds {
 		if cmd.PreRun {
@@ -65,7 +76,7 @@ func (a *App) PreRun(args []string) int {
 		}
 	}
 
-	if noop := run(prerunCmds, config.TemporalConfig{}, nil, args); noop {
+	if noop := run(prerunCmds, config.TemporalConfig{}, nil, args, a.cfg.Options); noop {
 		return CodeNoOp
 	}
 	return CodeOK
@@ -74,27 +85,39 @@ func (a *App) PreRun(args []string) int {
 // Run walks the command tree and executes them as appropriate.
 func (a *App) Run(cfg config.TemporalConfig, flags map[string]string, args []string) int {
 	if len(args) == 0 {
-		a.help()
+		a.help(args)
 		return CodeOK
 	}
 
-	if noop := run(a.cmds, cfg, flags, args); noop {
+	if a.cfg.Options != nil {
+		if err := a.cfg.Options.Parse(args); err != nil {
+			a.noop(args)
+			return CodeNoOp
+		}
+		args = a.cfg.Options.Args()
+	}
+
+	if noop := run(a.cmds, cfg, flags, args, a.cfg.Options); noop {
 		a.noop(args)
 		return CodeNoOp
 	}
 	return CodeOK
 }
 
-func (a *App) help() {
-	if len(os.Args) > 2 {
-		help(a.cfg.Desc, os.Args[0], os.Args[2:], a.cmds)
+func (a *App) help(args []string) {
+	if a.cfg.Options != nil {
+		a.cfg.Options.Parse(args)
+		args = a.cfg.Options.Args()
+	}
+	if len(args) >= 1 {
+		help(a.cfg.Desc, a.cfg.ExecName, args[1:], a.cmds, nil, a.cfg.Options)
 	} else {
-		help(a.cfg.Desc, os.Args[0], []string{}, a.cmds)
+		help(a.cfg.Desc, a.cfg.ExecName, []string{}, a.cmds, nil, a.cfg.Options)
 	}
 }
 
 func (a *App) noop(args []string) {
-	fmt.Printf("invalid invocation '%s %s'\n", a.cfg.ExecName, strings.Join(args[:], " "))
+	fmt.Printf("invalid invocation for '%s %s'\n", a.cfg.ExecName, strings.Join(args[:], " "))
 	fmt.Printf("\nUse '%s help [command]' to see CLI documentation.", a.cfg.ExecName)
 }
 

--- a/app.go
+++ b/app.go
@@ -55,7 +55,7 @@ func New(cmds map[string]Cmd, cfg Config) *App {
 // PreRun walks the command tree and executes commands marked as "PreRun" - this
 // is useful for running commands that do not need configuration to be read,
 // for example the built-in "help" command.
-func (a *App) PreRun(args []string) int {
+func (a *App) PreRun(flags map[string]string, args []string) int {
 	if len(args) == 0 {
 		a.help(args)
 		return CodeOK
@@ -76,7 +76,11 @@ func (a *App) PreRun(args []string) int {
 		}
 	}
 
-	if noop := run(prerunCmds, config.TemporalConfig{}, nil, args, a.cfg.Options); noop {
+	if flags == nil {
+		flags = map[string]string{}
+	}
+
+	if noop := run(prerunCmds, config.TemporalConfig{}, flags, args, a.cfg.Options); noop {
 		return CodeNoOp
 	}
 	return CodeOK

--- a/app.go
+++ b/app.go
@@ -101,6 +101,10 @@ func (a *App) Run(cfg config.TemporalConfig, flags map[string]string, args []str
 		args = a.cfg.Options.Args()
 	}
 
+	if flags == nil {
+		flags = map[string]string{}
+	}
+
 	if noop := run(a.cmds, cfg, flags, args, a.cfg.Options); noop {
 		a.noop(args)
 		return CodeNoOp

--- a/app_test.go
+++ b/app_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/RTradeLtd/config"
@@ -95,6 +96,9 @@ func TestApp_PreRun(t *testing.T) {
 }
 
 func TestApp_Run(t *testing.T) {
+	fl := flag.NewFlagSet("", flag.ExitOnError)
+	tflag := fl.String("test", "", "flag for testing")
+
 	type fields struct {
 		cfg  Config
 		cmds map[string]Cmd
@@ -155,6 +159,38 @@ func TestApp_Run(t *testing.T) {
 				Action: func(config.TemporalConfig, map[string]string) {},
 			}}},
 			args{[]string{"hi", "bobhead", "postables"}},
+			true,
+		},
+		{
+			"should run with a flag on command",
+			fields{Config{}, map[string]Cmd{"hi": Cmd{
+				Options: fl,
+				Action: func(cfg config.TemporalConfig, flags map[string]string) {
+					defer func() {
+						*tflag = ""
+					}()
+					if *tflag == "" {
+						t.Error("expected flag 'test' to have value")
+					}
+				},
+			}}},
+			args{[]string{"hi", "--test", "wow"}},
+			true,
+		},
+		{
+			"should run with a missing flag on command",
+			fields{Config{}, map[string]Cmd{"hi": Cmd{
+				Options: fl,
+				Action: func(cfg config.TemporalConfig, flags map[string]string) {
+					defer func() {
+						*tflag = ""
+					}()
+					if *tflag != "" {
+						t.Error("expected flag 'test' to have no value")
+					}
+				},
+			}}},
+			args{[]string{"hi"}},
 			true,
 		},
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -103,10 +103,10 @@ func TestApp_Run(t *testing.T) {
 		args []string
 	}
 	tests := []struct {
-		name      string
-		fields    fields
-		args      args
-		wantFound bool
+		name    string
+		fields  fields
+		args    args
+		wantRun bool
 	}{
 		{
 			"help command should run",
@@ -139,15 +139,32 @@ func TestApp_Run(t *testing.T) {
 			args{[]string{"me", "too", "wow"}},
 			true,
 		},
+		{
+			"should not run without required args",
+			fields{Config{}, map[string]Cmd{"hi": Cmd{
+				Args:   []string{"hello", "world"},
+				Action: func(config.TemporalConfig, map[string]string) {},
+			}}},
+			args{[]string{"hi"}},
+			false,
+		},
+		{
+			"should run with required args",
+			fields{Config{}, map[string]Cmd{"hi": Cmd{
+				Args:   []string{"hello", "world"},
+				Action: func(config.TemporalConfig, map[string]string) {},
+			}}},
+			args{[]string{"hi", "bobhead", "postables"}},
+			true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := New(tt.fields.cmds, tt.fields.cfg)
 			exit := a.Run(config.TemporalConfig{}, nil, tt.args.args)
-
-			if (exit == 0) != tt.wantFound {
+			if (exit == 0) != tt.wantRun {
 				t.Errorf("expected command run to be %v, got %v",
-					tt.wantFound, (exit == 0))
+					tt.wantRun, (exit == 0))
 			}
 		})
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -38,10 +38,10 @@ func TestApp_PreRun(t *testing.T) {
 		args []string
 	}
 	tests := []struct {
-		name      string
-		fields    fields
-		args      args
-		wantFound bool
+		name    string
+		fields  fields
+		args    args
+		wantRun bool
 	}{
 		{
 			"help command should run",
@@ -61,14 +61,34 @@ func TestApp_PreRun(t *testing.T) {
 			args{[]string{"notme"}},
 			false,
 		},
+		{
+			"should not run without required args",
+			fields{Config{}, map[string]Cmd{"hi": Cmd{
+				PreRun: true,
+				Args:   []string{"hello", "world"},
+				Action: func(config.TemporalConfig, map[string]string) {},
+			}}},
+			args{[]string{"hi"}},
+			false,
+		},
+		{
+			"should run with required args",
+			fields{Config{}, map[string]Cmd{"hi": Cmd{
+				PreRun: true,
+				Args:   []string{"hello", "world"},
+				Action: func(config.TemporalConfig, map[string]string) {},
+			}}},
+			args{[]string{"hi", "bobhead", "postables"}},
+			true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := New(tt.fields.cmds, tt.fields.cfg)
-			exit := a.PreRun(tt.args.args)
-			if (exit == 0) != tt.wantFound {
+			exit := a.PreRun(nil, tt.args.args)
+			if (exit == 0) != tt.wantRun {
 				t.Errorf("expected command run to be %v, got %v",
-					tt.wantFound, (exit == 0))
+					tt.wantRun, (exit == 0))
 			}
 		})
 	}

--- a/cmd.go
+++ b/cmd.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"flag"
+
 	"github.com/RTradeLtd/config"
 )
 
@@ -11,7 +13,11 @@ type Cmd struct {
 	Hidden        bool
 	PreRun        bool
 	ChildRequired bool
+	Children      map[string]Cmd
 
-	Action   func(cfg config.TemporalConfig, flags map[string]string)
-	Children map[string]Cmd
+	Args    []string      // names of required positional arguments. order is enforced
+	Options *flag.FlagSet // command flags
+
+	// flags include arguments loaded by Cmd.Args
+	Action func(cfg config.TemporalConfig, flags map[string]string)
 }

--- a/utils.go
+++ b/utils.go
@@ -20,11 +20,12 @@ func run(commands map[string]Cmd, cfg config.TemporalConfig,
 	}
 
 	// parse options
-	if c.Options != nil {
-		if err := c.Options.Parse(args); err != nil {
+	if c.Options != nil && len(args) > 0 {
+		if err := c.Options.Parse(args[1:]); err != nil {
 			return true
 		}
 		args = c.Options.Args()
+		fmt.Printf("%v\n", args)
 	}
 
 	// check for action and children

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"sort"
@@ -10,7 +11,7 @@ import (
 )
 
 func run(commands map[string]Cmd, cfg config.TemporalConfig,
-	flags map[string]string, args []string) (noop bool) {
+	flags map[string]string, args []string, baseOptions *flag.FlagSet) (noop bool) {
 
 	// find command
 	c, ok := commands[args[0]]
@@ -18,23 +19,41 @@ func run(commands map[string]Cmd, cfg config.TemporalConfig,
 		return true
 	}
 
+	// parse options
+	if c.Options != nil {
+		if err := c.Options.Parse(args); err != nil {
+			return true
+		}
+		args = c.Options.Args()
+	}
+
 	// check for action and children
 	if c.Action == nil && (c.Children == nil || len(c.Children) == 0) {
 		return true
 	} else if c.Action != nil {
+		// parse arguments
+		if c.Args != nil {
+			if len(args)-1 != len(c.Args) {
+				return true
+			}
+			for pos, name := range c.Args {
+				flags[name] = args[pos+1]
+			}
+		}
+		// execute action
 		c.Action(cfg, flags)
 	}
 
 	// check for children and walk through them based on conditions
 	if c.Children != nil && len(c.Children) > 0 {
 		if len(args) > 1 {
-			return run(c.Children, cfg, flags, args[1:])
+			return run(c.Children, cfg, flags, args[1:], baseOptions)
 		}
 		if c.ChildRequired {
 			if c.Description != "" {
-				help(c.Description, strings.Join(os.Args, " "), nil, c.Children)
+				help(c.Description, strings.Join(os.Args, " "), nil, c.Children, c.Args, baseOptions)
 			} else {
-				help(c.Blurb, strings.Join(os.Args, " "), nil, c.Children)
+				help(c.Blurb, strings.Join(os.Args, " "), nil, c.Children, c.Args, baseOptions)
 			}
 		}
 	}
@@ -42,18 +61,18 @@ func run(commands map[string]Cmd, cfg config.TemporalConfig,
 	return false
 }
 
-func help(doc, exec string, args []string, cmds map[string]Cmd) {
+func help(doc, exec string, args []string, cmds map[string]Cmd, requiredArgs []string, baseOptions *flag.FlagSet) {
 	if args != nil && len(args) > 0 {
 		c, found := cmds[args[0]]
 		if found {
 			exec += " " + args[0]
 			if c.Description != "" {
-				help(c.Description, exec, args[1:], c.Children)
+				help(c.Description, exec, args[1:], c.Children, c.Args, baseOptions)
 			} else {
-				help(c.Blurb, exec, args[1:], c.Children)
+				help(c.Blurb, exec, args[1:], c.Children, c.Args, baseOptions)
 			}
 		} else {
-			fmt.Printf("command %s %s not found\n", exec, strings.Join(args, " "))
+			fmt.Printf("command '%s %s' not found\n", exec, strings.Join(args, " "))
 		}
 		return
 	}
@@ -62,42 +81,77 @@ func help(doc, exec string, args []string, cmds map[string]Cmd) {
 		doc = "no documentation available"
 	}
 
-	if cmds == nil || len(cmds) == 0 {
-		println(doc)
-		return
+	// print main doc
+	println(doc)
+
+	// flags must be placed after first exec
+	var execParts = strings.SplitN(exec, " ", 2)
+	exec = strings.Join(execParts, " [OPTIONS] ")
+
+	// set required args
+	var required string
+	if requiredArgs != nil && len(requiredArgs) > 0 {
+		required = "[" + strings.Join(requiredArgs, "] [") + "]"
 	}
 
-	fmt.Printf(`%s
+	// print child command documentation if there are any
+	if len(cmds) > 0 {
+		fmt.Printf(`
+USAGE:
 
-usage:
+  %s [COMMAND]
 
-	%s [command]
+COMMANDS:
 
-commands:
+`, exec)
+		// calculate longest name
+		var sortedCommands = make([]string, 0)
+		var longestCmdNameLen = 0
+		for name := range cmds {
+			if cmds[name].Hidden {
+				continue
+			}
 
-`, doc, exec)
-
-	// calculate longest name
-	sortedCommands := make([]string, 0)
-	longestCmdNameLen := 0
-	for name := range cmds {
-		if cmds[name].Hidden {
-			continue
+			sortedCommands = append(sortedCommands, name)
+			if len(name) > longestCmdNameLen {
+				longestCmdNameLen = len(name)
+			}
 		}
+		sort.Strings(sortedCommands)
 
-		sortedCommands = append(sortedCommands, name)
-		if len(name) > longestCmdNameLen {
-			longestCmdNameLen = len(name)
+		// print help text for each command
+		for _, name := range sortedCommands {
+			dividerSpace := ""
+			for i := 0; i < longestCmdNameLen-len(name); i++ {
+				dividerSpace += " "
+			}
+			fmt.Printf("  %s%s  %s\n", name, dividerSpace, cmds[name].Blurb)
+		}
+	} else {
+		fmt.Printf(`
+USAGE:
+		
+  %s %s
+`, exec, required)
+	}
+
+	// print help text for flags
+	println(`
+OPTIONS:
+`)
+	var noOpts = true
+	if baseOptions != nil {
+		baseOptions.PrintDefaults()
+		noOpts = false
+	}
+	var calls = strings.Split(exec, " ")
+	for _, c := range calls {
+		if cmds[c].Options != nil {
+			cmds[c].Options.PrintDefaults()
+			noOpts = false
 		}
 	}
-	sort.Strings(sortedCommands)
-
-	// print help text for each command
-	for _, name := range sortedCommands {
-		dividerSpace := ""
-		for i := 0; i < longestCmdNameLen-len(name); i++ {
-			dividerSpace += " "
-		}
-		fmt.Printf("	%s%s  %s\n", name, dividerSpace, cmds[name].Blurb)
+	if noOpts {
+		println("  none")
 	}
 }


### PR DESCRIPTION
native support for flags and arguments!

## Arguments

```go
	"admin": {
		Hidden:      true,
		Blurb:       "assign user as an admin",
		Description: "Assign an existing Temporal user as an administrator.",
		Args:        []string{"dbAdmin"},
		Action: func(cfg config.TemporalConfig, args map[string]string) {
			if args["dbAdmin"] == "" {
				fmt.Println("dbAdmin flag not provided")
				os.Exit(1)
			}
                         // ...
```

## Flags

```go
func baseFlagSet() *flag.FlagSet {
	var f = flag.NewFlagSet("", flag.ExitOnError)

	// basic flags
	devMode = f.Bool("dev", false,
		"toggle dev mode")
	configPath = f.String("config", os.Getenv("CONFIG_DAG"),
		"path to Temporal configuration")

	// db configuration
	dbNoSSL = f.Bool("db.no_ssl", false,
		"toggle SSL connection with database")
	dbMigrate = f.Bool("db.migrate", false,
		"toggle whether a database migration should occur")

	// grpc configuration
	grpcNoSSL = f.Bool("grpc.no_ssl", false,
		"toggle SSL connection with GRPC services")

	// api configuration
	apiPort = f.String("api.port", "6767",
		"set port to expose API on")

	return f
}
```

```go
	temporal := cmd.New(commands, cmd.Config{
		Name:     "Temporal",
		ExecName: "temporal",
		Version:  Version,
		Desc:     "Temporal is an easy-to-use interface into distributed and decentralized storage technologies for personal and enterprise use cases.",
		Options:  baseFlagSet(),
	})
```

## New Help Messages

```
Interact with Temporal's various queue APIs

USAGE:

  temporal [OPTIONS] queue [COMMAND]

COMMANDS:

  dfa         Database file add queue
  email-send  Email send queue
  ipfs        IPFS queue sub commands

OPTIONS:

  -api.port string
        set port to expose API on (default "6767")
  -config string
        path to Temporal configuration
  -db.migrate
        toggle whether a database migration should occur
  -db.no_ssl
        toggle SSL connection with database
  -dev
        toggle dev mode
  -grpc.no_ssl
        toggle SSL connection with GRPC services
```

```
Create a Temporal user. Provide args as username, password, email. Do not use in production.

USAGE:

  temporal [OPTIONS] user [user] [pass] [email]

OPTIONS:

  -api.port string
        set port to expose API on (default "6767")
  -config string
        path to Temporal configuration
  -db.migrate
        toggle whether a database migration should occur
  -db.no_ssl
        toggle SSL connection with database
  -dev
        toggle dev mode
  -grpc.no_ssl
        toggle SSL connection with GRPC services
```